### PR TITLE
Update jetty-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <plugins>
             <plugin>
                 <!-- This plugin is needed for the servlet example -->
-                <groupId>org.mortbay.jetty</groupId>
+                <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-maven-plugin</artifactId>
                 <version>${jettyVersion}</version>
             </plugin>


### PR DESCRIPTION
`mvn package` through the following error for me:

```
[INFO] ------------------------------------------------------------------------
[ERROR] BUILD ERROR
[INFO] ------------------------------------------------------------------------
[INFO] Error building POM (may not be this project's POM).


Project ID: org.mortbay.jetty:jetty-maven-plugin

Reason: POM 'org.mortbay.jetty:jetty-maven-plugin' not found in repository: Unable to download the artifact from any repository

  org.mortbay.jetty:jetty-maven-plugin:pom:9.2.6.v20141205

from the specified remote repositories:
  central (http://repo1.maven.org/maven2),
  scm-manager release repository (http://maven.scm-manager.org/nexus/content/groups/public)

 for project org.mortbay.jetty:jetty-maven-plugin
```

Changing the group id allows maven to build SVNGit successfully, though I'm now having this error: 

```
[INFO] ------------------------------------------------------------------------
[ERROR] BUILD ERROR
[INFO] ------------------------------------------------------------------------
[INFO] Error building POM (may not be this project's POM).


Project ID: org.mortbay.jasper:jasper-jsp:pom:8.0.9.M3

Reason: Cannot find parent: org.eclipse.jetty:jetty-parent for project: org.mortbay.jasper:jasper-jsp:pom:8.0.9.M3 for project org.mortbay.jasper:jasper-jsp:pom:8.0.9.M3
```

[This error is on Stackexchange](http://stackoverflow.com/questions/28263782/web-application-jetty) but with no answers as yet. [This](https://bitbucket.org/fispace/apps/issue/44/issue-when-trying-to-run-the-getting) seems to suggest it is a problem with maven2 but I can't see maven3 in the Ubuntu repositories.

Is this fix helpful or just breaking things more? I'm not a java guy so help would be appreciated.
